### PR TITLE
fix bug with validator `date`

### DIFF
--- a/src/DateTimeWidget.php
+++ b/src/DateTimeWidget.php
@@ -101,7 +101,7 @@ class DateTimeWidget extends InputWidget
             'class' => 'form-control',
         ], $this->options);
 
-        if ($value !== null) {
+        if (!empty($value)) {
             $this->options['value'] = array_key_exists('value', $this->options)
                 ? $this->options['value']
                 : Yii::$app->formatter->asDatetime($value, $this->phpDatetimeFormat);


### PR DESCRIPTION
в это месте надо или еще проверку добавить на $value !== null && $value !== '' или empty
т.к., после валидации поисковой модели, поле уже будет не null, а "пустота", и в данном случае asDatetime отрабатывает и выводит всегда после сабмита 01.01.1970 00:00:00
